### PR TITLE
block: Skip the folio lock if the folio is already dirty

### DIFF
--- a/block/bio.c
+++ b/block/bio.c
@@ -1404,6 +1404,8 @@ void bio_set_pages_dirty(struct bio *bio)
 	struct folio_iter fi;
 
 	bio_for_each_folio_all(fi, bio) {
+		if (folio_test_dirty(fi.folio))
+			continue;
 		folio_lock(fi.folio);
 		folio_mark_dirty(fi.folio);
 		folio_unlock(fi.folio);


### PR DESCRIPTION
Pull request for series with
subject: block: Skip the folio lock if the folio is already dirty
version: 1
url: https://patchwork.kernel.org/project/linux-block/list/?series=928259
