### PR TITLE
dm: Enable inline crypto passthrough for striped target

### DIFF
--- a/drivers/md/dm-stripe.c
+++ b/drivers/md/dm-stripe.c
@@ -467,7 +467,7 @@ static struct target_type stripe_target = {
 	.name   = "striped",
 	.version = {1, 7, 0},
 	.features = DM_TARGET_PASSES_INTEGRITY | DM_TARGET_NOWAIT |
-		    DM_TARGET_ATOMIC_WRITES,
+		    DM_TARGET_ATOMIC_WRITES | DM_TARGET_PASSES_CRYPTO,
 	.module = THIS_MODULE,
 	.ctr    = stripe_ctr,
 	.dtr    = stripe_dtr,


### PR DESCRIPTION
Pull request for series with
subject: dm: Enable inline crypto passthrough for striped target
version: 1
url: https://patchwork.kernel.org/project/linux-block/list/?series=934412
