### PR TITLE
block: fix NULL pointer dereferenced within __blk_rq_map_sg

### DIFF
--- a/block/blk-merge.c
+++ b/block/blk-merge.c
@@ -556,10 +556,13 @@ int __blk_rq_map_sg(struct request_queue *q, struct request *rq,
 {
 	struct req_iterator iter = {
 		.bio	= rq->bio,
-		.iter	= rq->bio->bi_iter,
 	};
 	struct phys_vec vec;
 	int nsegs = 0;
+
+	/* the internal flush request may not have bio attached */
+	if (iter.bio)
+		iter.iter = iter.bio->bi_iter;
 
 	while (blk_map_iter_next(rq, &iter, &vec)) {
 		*last_sg = blk_next_sg(last_sg, sglist);


### PR DESCRIPTION
Pull request for series with
subject: block: fix NULL pointer dereferenced within __blk_rq_map_sg
version: 2
url: https://patchwork.kernel.org/project/linux-block/list/?series=934494
