### PR TITLE
block: fix conversion of GPT partition name to 7-bit

### DIFF
--- a/block/partitions/efi.c
+++ b/block/partitions/efi.c
@@ -682,7 +682,7 @@ static void utf16_le_to_7bit(const __le16 *in, unsigned int size, u8 *out)
 	out[size] = 0;
 
 	while (i < size) {
-		u8 c = le16_to_cpu(in[i]) & 0xff;
+		u8 c = le16_to_cpu(in[i]) & 0x7f;
 
 		if (c && !isprint(c))
 			c = '!';


### PR DESCRIPTION
Pull request for series with
subject: block: fix conversion of GPT partition name to 7-bit
version: 2
url: https://patchwork.kernel.org/project/linux-block/list/?series=935114
