### PR TITLE
blk-cgroup: improve policy registration error handling

### DIFF
--- a/.github/workflows/kernel_build.yml
+++ b/.github/workflows/kernel_build.yml
@@ -1,0 +1,28 @@
+name: blktests-ci
+
+on:
+  pull_request:
+
+jobs:
+  build-kernel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory '*'
+      - name: Checkout git
+        run: |
+          sudo apt-get install -y libelf-dev
+          mkdir -p linux
+          cd linux
+          git init
+          git remote add origin https://github.com/${{ github.repository }}
+          git fetch origin --depth=5 ${{ github.event.pull_request.head.sha }}
+          git reset --hard ${{ github.event.pull_request.head.sha }}
+          git log -1
+      - name: Build kernel
+        run: |
+          cd linux
+          make defconfig
+          make -j 8
+

--- a/block/blk-cgroup.c
+++ b/block/blk-cgroup.c
@@ -1727,26 +1727,26 @@ int blkcg_policy_register(struct blkcg_policy *pol)
 	struct blkcg *blkcg;
 	int i, ret;
 
-	mutex_lock(&blkcg_pol_register_mutex);
-	mutex_lock(&blkcg_pol_mutex);
-
-	/* find an empty slot */
-	ret = -ENOSPC;
-	for (i = 0; i < BLKCG_MAX_POLS; i++)
-		if (!blkcg_policy[i])
-			break;
-	if (i >= BLKCG_MAX_POLS) {
-		pr_warn("blkcg_policy_register: BLKCG_MAX_POLS too small\n");
-		goto err_unlock;
-	}
-
 	/*
 	 * Make sure cpd/pd_alloc_fn and cpd/pd_free_fn in pairs, and policy
 	 * without pd_alloc_fn/pd_free_fn can't be activated.
 	 */
 	if ((!pol->cpd_alloc_fn ^ !pol->cpd_free_fn) ||
 	    (!pol->pd_alloc_fn ^ !pol->pd_free_fn))
+		return -EINVAL;
+
+	mutex_lock(&blkcg_pol_register_mutex);
+	mutex_lock(&blkcg_pol_mutex);
+
+	/* find an empty slot */
+	for (i = 0; i < BLKCG_MAX_POLS; i++)
+		if (!blkcg_policy[i])
+			break;
+	if (i >= BLKCG_MAX_POLS) {
+		pr_warn("blkcg_policy_register: BLKCG_MAX_POLS too small\n");
+		ret = -ENOSPC;
 		goto err_unlock;
+	}
 
 	/* register @pol */
 	pol->plid = i;
@@ -1758,8 +1758,10 @@ int blkcg_policy_register(struct blkcg_policy *pol)
 			struct blkcg_policy_data *cpd;
 
 			cpd = pol->cpd_alloc_fn(GFP_KERNEL);
-			if (!cpd)
+			if (!cpd) {
+				ret = -ENOMEM;
 				goto err_free_cpds;
+			}
 
 			blkcg->cpd[pol->plid] = cpd;
 			cpd->blkcg = blkcg;


### PR DESCRIPTION
Pull request for series with
subject: blk-cgroup: improve policy registration error handling
version: 2
url: https://patchwork.kernel.org/project/linux-block/list/?series=933443
