### PR TITLE
block: Fix blk_sync_queue() to properly stop timeout timer

### DIFF
--- a/.github/workflows/kernel_build.yml
+++ b/.github/workflows/kernel_build.yml
@@ -1,0 +1,28 @@
+name: blktests-ci
+
+on:
+  pull_request:
+
+jobs:
+  build-kernel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory '*'
+      - name: Checkout git
+        run: |
+          sudo apt-get install -y libelf-dev
+          mkdir -p linux
+          cd linux
+          git init
+          git remote add origin https://github.com/${{ github.repository }}
+          git fetch origin --depth=5 ${{ github.event.pull_request.head.sha }}
+          git reset --hard ${{ github.event.pull_request.head.sha }}
+          git log -1
+      - name: Build kernel
+        run: |
+          cd linux
+          make defconfig
+          make -j 8
+

--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -1,0 +1,112 @@
+name: Run blktests
+
+on:
+  pull_request:
+
+env:
+  KERNEL_REF: "${{ github.event.pull_request.head.sha }}"
+  KERNEL_TREE: "https://github.com/${{ github.repository }}"
+
+#This workflow requires two k8s actions-runner-controllers (ARC) to be active.
+#One for building the kernel and fedora image and the other one for spawning the VM resource.
+jobs:
+  build-kernel:
+    #This step runs in a container in the k8s cluster 
+    runs-on: arc-kernel-builder
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+        with:
+          repository: linux-blktests/blktests-ci
+          path: blktests-ci
+
+      - name: Build kernel and package it into a containerimage
+        run: |
+          cd blktests-ci/playbooks/roles/kernel-builder-k8s-job/templates
+          docker build \
+            --build-arg KERNEL_TREE=${KERNEL_TREE} \
+            --build-arg KERNEL_REF=${KERNEL_REF} \
+            -t linux-kernel-containerdisk \
+            -f Dockerfile.linux-kernel-containerdisk . 2>&1 | tee build.log
+          #Setting KERNEL_VERSION var which is latern needed for notifying the VM what kernel to pick up
+          cat build.log | grep KERNEL_VERSION | awk '{print $3}' | grep KERNEL_VERSION >> $GITHUB_ENV
+
+      - name: Push the new Fedora containerimage with the freshly build kernel
+        run: |
+          docker tag linux-kernel-containerdisk registry-service.docker-registry.svc.cluster.local/linux-kernel-containerdisk:${KERNEL_VERSION}
+          docker push registry-service.docker-registry.svc.cluster.local/linux-kernel-containerdisk:${KERNEL_VERSION}
+
+      - name: Notifying the next job to pick up the Fedora image with the correct tag that we just build
+        run: |
+          echo "${KERNEL_VERSION}"
+
+  run-tests-on-kernel:
+    #ATTENTION! This section formats all available NVMe devices. Be careful when changing the `runs-on` tag!
+    #This step runs in a VM with the previously compiled kernel in the k8s cluster 
+    runs-on: arc-vm-runner-set
+    needs: build-kernel
+    steps:
+      - name: Print VM debug info
+        run: |
+          uname -a
+          cat /etc/os-release
+          lsblk
+
+      #We create .info files that contain the KERNEL_VERSION tag in the
+      #modules tree when building the kernel
+      - name: Verify that we are running the correct kernel
+        run: |
+          cat /usr/lib/modules/*.info | grep "${KERNEL_VERSION}" 
+
+      - name: Install build dependencies for blktests
+        run: |
+          sudo dnf install -y gcc \
+          clang \
+          make \
+          util-linux \
+          llvm \
+          gawk \
+          fio \
+          udev \
+          kmod \
+          coreutils \
+          gcc \
+          gzip \
+          e2fsprogs \
+          xfsprogs \
+          f2fs-tools \
+          btrfs-progs \
+          device-mapper-multipath \
+          nbd \
+          device-mapper \
+          unzip \
+          jq \
+          nvme-cli \
+          git \
+          wget
+
+      - name: Checkout blktests
+        uses: actions/checkout@v4
+        with:
+          repository: osandov/blktests
+          path: blktests
+
+      - name: Build blktests
+        run: |
+          cd blktests
+          make
+
+      - name: Configure blktests
+        run: |
+          cd blktests
+          cat > config << EOF
+          TEST_DEVS=(${ZBD0})
+          DEVICE_ONLY=1
+          EOF
+
+      - name: Run ZBD Tests
+        run: |
+          cd blktests
+          sudo ./check zbd
+        env: 
+          RUN_ZONED_TESTS: 1

--- a/block/blk-core.c
+++ b/block/blk-core.c
@@ -219,8 +219,11 @@ EXPORT_SYMBOL_GPL(blk_status_to_str);
  */
 void blk_sync_queue(struct request_queue *q)
 {
-	timer_delete_sync(&q->timeout);
+	blk_queue_flag_set(QUEUE_FLAG_NOTIMEOUT, q);
+	synchronize_rcu();
 	cancel_work_sync(&q->timeout_work);
+	timer_delete_sync(&q->timeout);
+	blk_queue_flag_clear(QUEUE_FLAG_NOTIMEOUT, q);
 }
 EXPORT_SYMBOL(blk_sync_queue);
 
@@ -383,7 +386,10 @@ static void blk_rq_timed_out_timer(struct timer_list *t)
 {
 	struct request_queue *q = timer_container_of(q, t, timeout);
 
-	kblockd_schedule_work(&q->timeout_work);
+	rcu_read_lock();
+	if (!blk_queue_notimeout(q))
+		kblockd_schedule_work(&q->timeout_work);
+	rcu_read_unlock();
 }
 
 static void blk_timeout_work(struct work_struct *work)

--- a/block/blk-mq-debugfs.c
+++ b/block/blk-mq-debugfs.c
@@ -81,6 +81,7 @@ static int queue_pm_only_show(void *data, struct seq_file *m)
 #define QUEUE_FLAG_NAME(name) [QUEUE_FLAG_##name] = #name
 static const char *const blk_queue_flag_name[] = {
 	QUEUE_FLAG_NAME(DYING),
+	QUEUE_FLAG_NAME(NOTIMEOUT),
 	QUEUE_FLAG_NAME(NOMERGES),
 	QUEUE_FLAG_NAME(SAME_COMP),
 	QUEUE_FLAG_NAME(FAIL_IO),

--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -633,6 +633,7 @@ struct request_queue {
 /* Keep blk_queue_flag_name[] in sync with the definitions below */
 enum {
 	QUEUE_FLAG_DYING,		/* queue being torn down */
+	QUEUE_FLAG_NOTIMEOUT,		/* do not schedule timeout work */
 	QUEUE_FLAG_NOMERGES,		/* disable merge attempts */
 	QUEUE_FLAG_SAME_COMP,		/* complete on same CPU-group */
 	QUEUE_FLAG_FAIL_IO,		/* fake timeout */
@@ -657,6 +658,7 @@ void blk_queue_flag_clear(unsigned int flag, struct request_queue *q);
 
 #define blk_queue_dying(q)	test_bit(QUEUE_FLAG_DYING, &(q)->queue_flags)
 #define blk_queue_init_done(q)	test_bit(QUEUE_FLAG_INIT_DONE, &(q)->queue_flags)
+#define blk_queue_notimeout(q)	test_bit(QUEUE_FLAG_NOTIMEOUT, &(q)->queue_flags)
 #define blk_queue_nomerges(q)	test_bit(QUEUE_FLAG_NOMERGES, &(q)->queue_flags)
 #define blk_queue_noxmerges(q)	\
 	test_bit(QUEUE_FLAG_NOXMERGES, &(q)->queue_flags)


### PR DESCRIPTION
Pull request for series with
subject: block: Fix blk_sync_queue() to properly stop timeout timer
version: 1
url: https://patchwork.kernel.org/project/linux-block/list/?series=967447
