### PR TITLE
rust: replace kernel::str::CStr w/ core::ffi::CStr

### DIFF
--- a/.github/workflows/kernel_build.yml
+++ b/.github/workflows/kernel_build.yml
@@ -1,0 +1,28 @@
+name: blktests-ci
+
+on:
+  pull_request:
+
+jobs:
+  build-kernel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory '*'
+      - name: Checkout git
+        run: |
+          sudo apt-get install -y libelf-dev
+          mkdir -p linux
+          cd linux
+          git init
+          git remote add origin https://github.com/${{ github.repository }}
+          git fetch origin --depth=5 ${{ github.event.pull_request.head.sha }}
+          git reset --hard ${{ github.event.pull_request.head.sha }}
+          git log -1
+      - name: Build kernel
+        run: |
+          cd linux
+          make defconfig
+          make -j 8
+

--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -1,0 +1,91 @@
+name: Run blktests
+
+on:
+  pull_request:
+
+env:
+  KERNEL_REF: "${{ github.event.pull_request.head.sha }}"
+  KERNEL_TREE: "https://github.com/${{ github.repository }}"
+
+#This workflow requires an actions-runner-controllers (ARC) to be active.
+#The k8s cluster of this ARC needs KubeVirt to be installed.
+jobs:
+  build-and-test-kernel:
+    #This step runs in a container in the k8s cluster 
+    runs-on: arc-vm-shinichiro-linux-block
+    steps:
+      - name: Checkout blktests-ci
+        uses: actions/checkout@v4
+        with:
+          repository: linux-blktests/blktests-ci
+          path: blktests-ci
+
+      - name: Build kernel and package it into a containerimage
+        run: |
+          cd blktests-ci/playbooks/roles/kernel-builder-k8s-job/templates
+          docker build \
+            --build-arg KERNEL_TREE=${KERNEL_TREE} \
+            --build-arg KERNEL_REF=${KERNEL_REF} \
+            -t linux-kernel-containerdisk \
+            -f Dockerfile.linux-kernel-containerdisk . 2>&1 | tee build.log
+          #Setting KERNEL_VERSION var which is latern needed for notifying the VM what kernel to pick up
+          cat build.log | grep KERNEL_VERSION | awk '{print $3}' | grep KERNEL_VERSION >> $GITHUB_ENV
+
+      - name: Push the new Fedora containerimage with the freshly build kernel
+        run: |
+          docker tag linux-kernel-containerdisk registry-service.docker-registry.svc.cluster.local/linux-kernel-containerdisk:${KERNEL_VERSION}
+          docker push registry-service.docker-registry.svc.cluster.local/linux-kernel-containerdisk:${KERNEL_VERSION}
+
+      - name: Run in VM
+        uses: ./blktests-ci/.github/actions/kubevirt-action
+        with:
+          kernel_version: ${{ env.KERNEL_VERSION }}
+          run_cmds: |
+            #Print VM debug info
+            uname -a
+            cat /etc/os-release
+            lsblk
+
+            #Install build dependencies for blktests
+            sudo dnf install -y gcc \
+            clang \
+            make \
+            util-linux \
+            llvm \
+            gawk \
+            fio \
+            udev \
+            kmod \
+            coreutils \
+            gcc \
+            gzip \
+            e2fsprogs \
+            xfsprogs \
+            f2fs-tools \
+            btrfs-progs \
+            device-mapper-multipath \
+            nbd \
+            device-mapper \
+            unzip \
+            jq \
+            nvme-cli \
+            git \
+            wget
+
+            git clone https://github.com/linux-blktests/blktests.git
+
+            cd blktests
+            make
+
+            cat > config << EOF
+            TEST_DEVS=(${ZBD0})
+            DEVICE_ONLY=1
+            EOF
+
+            #ATTENTION! This section formats all available NVMe devices. Be careful when changing the `runs-on` tag!
+            #This step runs in a VM with the previously compiled kernel in the k8s cluster 
+
+            # Run ZBD blktests
+
+            export RUN_ZONED_TESTS=1
+            sudo ./check zbd


### PR DESCRIPTION
Pull request for series with
subject: rust: replace kernel::str::CStr w/ core::ffi::CStr
version: 13
url: https://patchwork.kernel.org/project/linux-block/list/?series=977826
