### PR TITLE
block: fix FS_IOC_GETLBMD_CAP parsing in blkdev_common_ioctl()

### DIFF
--- a/block/ioctl.c
+++ b/block/ioctl.c
@@ -643,9 +643,16 @@ static int blkdev_common_ioctl(struct block_device *bdev, blk_mode_t mode,
 		return blkdev_pr_preempt(bdev, mode, argp, true);
 	case IOC_PR_CLEAR:
 		return blkdev_pr_clear(bdev, mode, argp);
-	default:
-		return -ENOIOCTLCMD;
 	}
+
+	if (_IOC_DIR(cmd)  == _IOC_DIR(FS_IOC_GETLBMD_CAP) &&
+	    _IOC_TYPE(cmd) == _IOC_TYPE(FS_IOC_GETLBMD_CAP) &&
+	    _IOC_NR(cmd)   == _IOC_NR(FS_IOC_GETLBMD_CAP) &&
+	    _IOC_SIZE(cmd) >= LBMD_SIZE_VER0 &&
+	    _IOC_SIZE(cmd) <= _IOC_SIZE(FS_IOC_GETLBMD_CAP))
+		return blk_get_meta_cap(bdev, cmd, argp);
+
+	return -ENOIOCTLCMD;
 }
 
 /*


### PR DESCRIPTION
Pull request for series with
subject: block: fix FS_IOC_GETLBMD_CAP parsing in blkdev_common_ioctl()
version: 1
url: https://patchwork.kernel.org/project/linux-block/list/?series=980640
